### PR TITLE
SSH Refactoring, breakout pipelines. Add generateName for pipeline ru…

### DIFF
--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: p-git-collin-test
+spec:
+  description: |
+    prints the README.md from the selected repo & branch
+  params:
+    - name: repo-url
+      type: string
+      description: The git repository URL to clone from.
+    - name: branch-name
+      type: string
+      description: The git branch to clone.
+  workspaces:
+    - name: shared-data
+      description: |
+        This workspace will receive the cloned git repo and be passed
+        to the next Task for the repo's README.md file to be read.
+    - name: ssh-creds
+      description: |
+        This workspace will provide ssh credentials to the git-clone task.
+  tasks:
+    - name: fetch-repo
+      taskRef:
+        name: git-clone
+      workspaces:
+      - name: output
+        workspace: shared-data
+      - name: ssh-directory
+        workspace: ssh-creds
+      params:
+      - name: url
+        value: $(params.repo-url)
+      - name: revision
+        value: $(params.branch-name)
+#    - name: cat-readme
+#      runAfter: ["fetch-repo"] # Wait until the clone is done before reading the readme.
+#      workspaces:
+#      - name: source
+#        workspace: shared-data
+#      taskSpec:
+#        workspaces:
+#        - name: source
+#        steps:
+#        - image: zshusers/zsh:4.3.15
+#          script: |
+#            #!/usr/bin/env zsh
+#            cat $(workspaces.source.path)/README.md

--- a/tekton/run.yaml
+++ b/tekton/run.yaml
@@ -1,0 +1,35 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: git-clone-checking-out-a-branch-
+spec:
+#  podTemplate:
+#    affinity:
+#      podAntiAffinity:
+#        requiredDuringSchedulingIgnoredDuringExecution:
+#          - labelSelector:
+#              matchExpressions:
+#              - key: "tekton.dev/pipelineRun"
+#                operator: In
+#                values:
+#                - git-clone-checking-out-a-branch
+#            topologyKey: kubernetes.io/hostname
+  pipelineRef:
+    name: p-git-collin-test
+  workspaces:
+    - name: shared-data
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+    - name: ssh-creds
+      secret:
+        secretName: tkn-ssh-credentials
+  params:
+  - name: repo-url
+    value: git@github.com:gregnrobinson/envoytun.git
+  - name: branch-name
+    value: main

--- a/tekton/task.yaml
+++ b/tekton/task.yaml
@@ -1,90 +1,4 @@
 apiVersion: tekton.dev/v1beta1
-kind: Pipeline
-metadata:
-  name: cat-branch-readme
-spec:
-  description: |
-    prints the README.md from the selected repo & branch
-  params:
-    - name: repo-url
-      type: string
-      description: The git repository URL to clone from.
-    - name: branch-name
-      type: string
-      description: The git branch to clone.
-  workspaces:
-    - name: shared-data
-      description: |
-        This workspace will receive the cloned git repo and be passed
-        to the next Task for the repo's README.md file to be read.
-    - name: ssh-creds
-      description: |
-        This workspace will provide ssh credentials to the git-clone task.
-  tasks:
-    - name: fetch-repo
-      taskRef:
-        name: git-clone
-      workspaces:
-      - name: output
-        workspace: shared-data
-      - name: ssh-directory
-        workspace: ssh-creds
-      params:
-      - name: url
-        value: $(params.repo-url)
-      - name: revision
-        value: $(params.branch-name)
-    - name: cat-readme
-      runAfter: ["fetch-repo"] # Wait until the clone is done before reading the readme.
-      workspaces:
-      - name: source
-        workspace: shared-data
-      taskSpec:
-        workspaces:
-        - name: source
-        steps:
-        - image: zshusers/zsh:4.3.15
-          script: |
-            #!/usr/bin/env zsh
-            cat $(workspaces.source.path)/README.md
----
-apiVersion: tekton.dev/v1beta1
-kind: PipelineRun
-metadata:
-  name: git-clone-checking-out-a-branch
-spec:
-  podTemplate:
-    affinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: "tekton.dev/pipelineRun"
-                operator: In
-                values:
-                - git-clone-checking-out-a-branch
-            topologyKey: kubernetes.io/hostname
-  pipelineRef:
-    name: cat-branch-readme
-  workspaces:
-    - name: shared-data
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-          - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-    - name: ssh-creds
-      secret:
-        secretName: github-cmf-microservices
-  params:
-  - name: repo-url
-    value: git@github.com:my-private/private-repository.git
-  - name: branch-name
-    value: oc-dev
----
-apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: git-clone
@@ -116,14 +30,14 @@ spec:
         the user's home before git commands are executed. Used to authenticate
         with the git remote when performing the clone. Binding a Secret to this
         Workspace is strongly recommended over other volume types.
-    - name: basic-auth
-      optional: true
-      description: |
-        A Workspace containing a .gitconfig and .git-credentials file. These
-        will be copied to the user's home before any git commands are run. Any
-        other files in this Workspace are ignored. It is strongly recommended
-        to use ssh-directory over basic-auth whenever possible and to bind a
-        Secret to this Workspace over other volume types.
+#    - name: basic-auth
+#      optional: true
+#      description: |
+#        A Workspace containing a .gitconfig and .git-credentials file. These
+#        will be copied to the user's home before any git commands are run. Any
+#        other files in this Workspace are ignored. It is strongly recommended
+#        to use ssh-directory over basic-auth whenever possible and to bind a
+#        Secret to this Workspace over other volume types.
   params:
     - name: url
       description: Repository URL to clone from.
@@ -255,8 +169,8 @@ spec:
           chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
           # the stock git-clone V0.4 doesn't seem to leverage the ssh-privatekey unless it's added to a keychain.
           # This has worked for me.  It needs to be verified and once it has should be PRd upstream.
-          eval `ssh-agent -s`
-          ssh-add ${PARAM_USER_HOME}/.ssh/ssh-privatekey
+          #eval `ssh-agent -s`
+          #ssh-add ${PARAM_USER_HOME}/.ssh/ssh-privatekey
         fi
 
         CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"

--- a/tekton/task.yaml
+++ b/tekton/task.yaml
@@ -30,14 +30,14 @@ spec:
         the user's home before git commands are executed. Used to authenticate
         with the git remote when performing the clone. Binding a Secret to this
         Workspace is strongly recommended over other volume types.
-#    - name: basic-auth
-#      optional: true
-#      description: |
-#        A Workspace containing a .gitconfig and .git-credentials file. These
-#        will be copied to the user's home before any git commands are run. Any
-#        other files in this Workspace are ignored. It is strongly recommended
-#        to use ssh-directory over basic-auth whenever possible and to bind a
-#        Secret to this Workspace over other volume types.
+    - name: basic-auth
+      optional: true
+      description: |
+        A Workspace containing a .gitconfig and .git-credentials file. These
+        will be copied to the user's home before any git commands are run. Any
+        other files in this Workspace are ignored. It is strongly recommended
+        to use ssh-directory over basic-auth whenever possible and to bind a
+        Secret to this Workspace over other volume types.
   params:
     - name: url
       description: Repository URL to clone from.


### PR DESCRIPTION
## Problem Code

```bash
the stock git-clone V0.4 doesn't seem to leverage the ssh-privatekey unless it's added to a keychain.
This has worked for me.  It needs to be verified and once it has should be PRd upstream.
eval `ssh-agent -s`
ssh-add ${PARAM_USER_HOME}/.ssh/ssh-privatekey
```

## My SSH Secret
```
Name:         tkn-ssh-credentials
Namespace:    e595b8-dev
Labels:       <none>
Annotations:  <none>

Type:  Opaque

Data
====
id_rsa:  2635 bytes
```

I think the problem is because my key is named `id_rsa` which removes the requirement for the steps you are adding. By default, Linux will search for `id_rsa` when connecting to a remote host using ssh. Because your key is named otherwise, it creates this necessity to add it as an alternative identity. Info on doing this is below. I would recommend just naming it `id_rsa` and calling it a day.  No need to complicate things.

For info on id_rsa default naming, you can look here: https://askubuntu.com/questions/30788/does-ssh-key-need-to-be-named-id-rsa.

## Using multiple keys
It's not uncommon to use multiple keys. Instead of running ssh user@host -i /path/to/identity_file, you can use a configuration file, ~/.ssh/config.

Common settings are the IdentityFile (the keys) and port. The next configuration will check "id_dsa" and "bender" only when connecting with ssh youruser@yourhost:
```bash
Host yourhost
   IdentityFile ~/.ssh/id_dsa
   IdentityFile ~/.ssh/bender
```
If you omit Host yourhost, the settings will apply to all SSH connections. Other options can also be specified for this host match, like User youruser, Port 2222, etc. This would allow you to connect with the shorthand ssh yourhost instead of ssh -p2222 youruser@yourhost -i ~/.ssh/id_dsa -i ~/.ssh/bender.

[Reference](https://askubuntu.com/questions/30788/does-ssh-key-need-to-be-named-id-rsa)

[More Info](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
